### PR TITLE
prevent scrollPos to contain decimal

### DIFF
--- a/packages/conveyer/src/Conveyer.ts
+++ b/packages/conveyer/src/Conveyer.ts
@@ -478,7 +478,7 @@ class Conveyer extends Component<ConveyerEvents> {
     } else if (align === "end") {
       scrollPos = itemPos + itemSize - size + padding;
     } else if (align === "center") {
-      scrollPos = itemPos + itemSize / 2 - size / 2 + padding;
+      scrollPos = Math.floor(itemPos + itemSize / 2 - size / 2 + padding);
     }
     return scrollPos;
   }


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
Haven't opened a separate issue.

## Details
<!-- Detailed description of the change/feature -->
scrollPos sometimes return number with `.5` decimal.
This causes `isReachEnd` to always return false even though scroll has reached the end position, since `{element}.scrollWidth - {element}.scrollLeft` returns `offsetWidth + 0.5`.