### PR TITLE
fix: set isReachEnd

### DIFF
--- a/packages/conveyer/src/Conveyer.ts
+++ b/packages/conveyer/src/Conveyer.ts
@@ -516,7 +516,7 @@ class Conveyer extends Component<ConveyerEvents> {
       this.trigger("leaveStart");
     }
     // enter end
-    if (pos >= scrollSize - size && this.isReachEnd !== true) {
+    if ((pos >= scrollSize - size || scrollSize - size - pos < 1) && this.isReachEnd !== true) {
       this._isReachEnd = true;
       /**
        * This event is fired when scroll reach end.

--- a/packages/conveyer/src/Conveyer.ts
+++ b/packages/conveyer/src/Conveyer.ts
@@ -516,7 +516,7 @@ class Conveyer extends Component<ConveyerEvents> {
       this.trigger("leaveStart");
     }
     // enter end
-    if ((pos >= scrollSize - size || scrollSize - size - pos < 1) && this.isReachEnd !== true) {
+    if (scrollSize - size - pos < 1 && this.isReachEnd !== true) {
       this._isReachEnd = true;
       /**
        * This event is fired when scroll reach end.


### PR DESCRIPTION
## Details
<!-- Detailed description of the change/feature -->

isReachEnd has bugs of being true when the scroll has reached the end on some device
This is due to a bug in the scrollLeft on some device of having a decimal value
In order to prevent the bug, this fix adds additional calculation.
When `scrollSize - size - pos < 1`, it means the scroll has reached the end, but has a decimal scrollLeft value.
Thus, it would be safe to assume, that it has reached the end if the above condition returns true

