### PR TITLE
feat: add useWheel option

### DIFF
--- a/packages/conveyer/package-lock.json
+++ b/packages/conveyer/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.1.0",
 			"license": "MIT",
 			"dependencies": {
-				"@egjs/axes": "^3.2.0",
+				"@egjs/axes": "^3.2.2",
 				"@egjs/component": "^3.0.1"
 			},
 			"devDependencies": {
@@ -348,9 +348,9 @@
 			"integrity": "sha512-ENhwkOW6rnYW8IuXJwvECIAzj7nMxq+ctB8uCJ+mKnoKK8tGiv3YXtN6nuaOov2YmXdRdwafSz9rhgRNXswX/A=="
 		},
 		"node_modules/@egjs/axes": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-3.2.0.tgz",
-			"integrity": "sha512-PF4PlCbLPvbWlugzQ0pMQ00WMw52WHgPA+qHtMCWB3/+ZuJ5SZcyt61xvD0R9291N+dDLE2TBwpOsQGRqcoioQ==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-3.2.2.tgz",
+			"integrity": "sha512-1GKMQIHv/GYHPM6ccusyybmLOTA0nUMnRajiNjahVFdOcwglS9pUiYpo23MreVuLSUlQvjPWWHQP/LzGPNTTKA==",
 			"dependencies": {
 				"@egjs/agent": "^2.2.1",
 				"@egjs/component": "^3.0.1"
@@ -6772,9 +6772,9 @@
 			"integrity": "sha512-ENhwkOW6rnYW8IuXJwvECIAzj7nMxq+ctB8uCJ+mKnoKK8tGiv3YXtN6nuaOov2YmXdRdwafSz9rhgRNXswX/A=="
 		},
 		"@egjs/axes": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-3.2.0.tgz",
-			"integrity": "sha512-PF4PlCbLPvbWlugzQ0pMQ00WMw52WHgPA+qHtMCWB3/+ZuJ5SZcyt61xvD0R9291N+dDLE2TBwpOsQGRqcoioQ==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-3.2.2.tgz",
+			"integrity": "sha512-1GKMQIHv/GYHPM6ccusyybmLOTA0nUMnRajiNjahVFdOcwglS9pUiYpo23MreVuLSUlQvjPWWHQP/LzGPNTTKA==",
 			"requires": {
 				"@egjs/agent": "^2.2.1",
 				"@egjs/component": "^3.0.1"

--- a/packages/conveyer/package.json
+++ b/packages/conveyer/package.json
@@ -31,7 +31,7 @@
 		"drag"
 	],
 	"dependencies": {
-		"@egjs/axes": "^3.2.0",
+		"@egjs/axes": "^3.2.2",
 		"@egjs/component": "^3.0.1"
 	},
 	"devDependencies": {

--- a/packages/conveyer/src/Conveyer.ts
+++ b/packages/conveyer/src/Conveyer.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2022-present NAVER Corp.
  * MIT license
  */
-import Axes, { PanInput } from "@egjs/axes";
+import Axes, { PanInput, WheelInput } from "@egjs/axes";
 import Component from "@egjs/component";
 import { IS_IE } from "./browser";
 import { ReactiveSubscribe, Reactive, Ref } from "./cfcs";
@@ -108,6 +108,7 @@ class Conveyer extends Component<ConveyerEvents> {
     this._options = {
       horizontal: true,
       useDrag: true,
+      useWheel: true,
       autoInit: true,
       scrollDebounce: 100,
       ...options,
@@ -385,13 +386,13 @@ class Conveyer extends Component<ConveyerEvents> {
       "hold": e => {
         isHold = true;
         isDrag = false;
-        const inputEvent = e.inputEvent.srcEvent;
+        const nativeEvent = e.inputEvent.srcEvent ? e.inputEvent.srcEvent : e.inputEvent;
 
-        if (!inputEvent) {
+        if (!nativeEvent) {
           return;
         }
         if (options.preventDefault) {
-          inputEvent.preventDefault();
+          nativeEvent.preventDefault();
         }
         if (options.preventClickOnDrag) {
           this._disableClick();
@@ -411,7 +412,7 @@ class Conveyer extends Component<ConveyerEvents> {
         } else {
           scrollAreaElement.scrollTop -= scroll;
         }
-        if (options.nested && e.inputEvent.srcEvent) {
+        if (options.nested) {
           this._checkNestedMove(e);
         }
       },
@@ -425,11 +426,18 @@ class Conveyer extends Component<ConveyerEvents> {
     });
 
     this._axes = axes;
-    if (this._options.useDrag) {
-      axes.connect(this._options.horizontal ? ["scroll", ""] : ["", "scroll"], new PanInput(scrollAreaElement, {
+    if (options.useDrag) {
+      axes.connect(options.horizontal ? ["scroll", ""] : ["", "scroll"], new PanInput(scrollAreaElement, {
         inputType: ["mouse"],
         touchAction: "auto",
       }));
+    }
+    if (options.useWheel && options.horizontal) {
+      axes.connect(["scroll", ""], new WheelInput(scrollAreaElement, {
+        scale: 30,
+      }));
+    } else if (!options.useWheel) {
+      scrollAreaElement.addEventListener("wheel", (e) => e.preventDefault());
     }
     scrollAreaElement.addEventListener("scroll", this._onScroll);
     window.addEventListener("resize", this.update);
@@ -484,7 +492,8 @@ class Conveyer extends Component<ConveyerEvents> {
   }
   private _checkNestedMove(e: any) {
     if (this.isReachStart || this.isReachEnd) {
-      e.inputEvent.srcEvent.__childrenAxesAlreadyChanged = false;
+      const nativeEvent = e.inputEvent.srcEvent ? e.inputEvent.srcEvent : e.inputEvent;
+      nativeEvent.__childrenAxesAlreadyChanged = false;
     }
   }
   private _onScroll = (e?: any) => {

--- a/packages/conveyer/src/types.ts
+++ b/packages/conveyer/src/types.ts
@@ -10,6 +10,7 @@ import Conveyer from "./Conveyer";
  * @property - scroll direction. (true: Horizontal Scroll, false: Vertical Scroll)  (default: true) <ko>스크롤 방향. (true: 가로 스크롤, false: 세로 스크롤) (default: true)</ko>
  * @property - selector to find items inside. (default: "") <ko>내부의 아이템들을 찾기 위한 selector. (default: "")</ko>
  * @property - Whether to use drag (default: true) <ko> 드래그를 사용할지 여부. (default: true)</ko>
+ * @property - Whether to use the mouse wheel input for same scroll direction (default: true) <ko>스크롤 방향으로 마우스 휠 입력을 사용할지 여부. (default: true)</ko>
  * @property - The maximum amount of time the scroll event does not fire for the finishScroll event to be triggered. (default: 100) <ko> finishScroll 이벤트가 발생되기 위한 scroll 이벤트가 발생하지 않는 최대 시간. (default: 100)</ko>
  * @property - Whether to prevent being selected. (default: true) <ko>셀렉트가 되는 것을 막을지 여부. (default: true) </ko>
  * @property - Whether to prevent click event when dragging. (default: false) <ko>드래그하면 클릭이벤트를 막을지 여부. (default: true)</ko>
@@ -20,6 +21,7 @@ export interface ConveyerOptions {
   horizontal?: boolean;
   itemSelector?: string;
   useDrag?: boolean;
+  useWheel?: boolean;
   scrollDebounce?: number;
   preventDefault?: boolean;
   preventClickOnDrag?: boolean;

--- a/packages/conveyer/test/unit/Conveyer.spec.ts
+++ b/packages/conveyer/test/unit/Conveyer.spec.ts
@@ -1,6 +1,7 @@
 import {
   cleanup,
   dispatchDrag,
+  dispatchMouseWheel,
   sandbox,
   waitEvent,
   waitFor,
@@ -597,6 +598,28 @@ describe("test Conveyer", () => {
     });
   });
   describe("Options", () => {
+    describe("useWheel", () => {
+      [true, false].forEach(useWheel => {
+        it(`should check if the target is moved by the mouse wheel only when useWheel is true (useWheel: ${useWheel})`, async () => {
+          // Given
+          conveyer = new Conveyer(".items", {
+            useWheel,
+          });
+
+          // When
+          await dispatchMouseWheel(
+            document.querySelector<HTMLElement>(".items")!,
+            600,
+            { duration: 200, interval: 10 }
+          );
+          await waitFor(200); // wait until release animation is finished
+
+          // Then
+          expect(conveyer.scrollPos).to.be.equals(useWheel ? 600 : 0);
+        });
+      });
+    });
+
     describe("nested", () => {
       let childConveyer!: Conveyer;
 

--- a/packages/conveyer/test/unit/utils/utils.ts
+++ b/packages/conveyer/test/unit/utils/utils.ts
@@ -99,3 +99,16 @@ export async function dispatchMouseMove(target: HTMLElement, moustInit: any, tim
     target.dispatchEvent(mousemove);
   }, time);
 }
+
+export async function dispatchMouseWheel(
+  target: HTMLElement,
+  deltaY: number,
+  options: { duration: number; interval: number }
+) {
+  const count = Math.floor(options.duration / options.interval);
+  for (let i = 1; i <= count; ++i) {
+    const wheelEvent = new WheelEvent("wheel", { deltaY: deltaY / count });
+    target.dispatchEvent(wheelEvent);
+    await waitFor(options.interval);
+  }
+}


### PR DESCRIPTION
## Details
Added `useWheel` to ConveyerOptions. The default value is true.
`useWheel` decides whether to use the mouse wheel input for same scroll direction.

If direction is horizontal and `useWheel` is `true`, the mouse wheel can move the Conveyer horizontally.
If direction is horizontal and `useWheel` is `false`, the Conveyer moves only by drag as same as before.

If direction is vertical and `useWheel` is `true`, the Conveyer moves by drag and mouse wheel as same as before.
If direction is vertical and `useWheel` is `false`, the Conveyer moves only by drag.

If you want to use it as the same Conveyer as before, set useWheel to `true` for vertical and `false` for horizontal.