### PR TITLE
feat: use side wheel to move conveyer

### DIFF
--- a/packages/conveyer/package-lock.json
+++ b/packages/conveyer/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.2.0",
 			"license": "MIT",
 			"dependencies": {
-				"@egjs/axes": "^3.2.2",
+				"@egjs/axes": "^3.4.0",
 				"@egjs/component": "^3.0.1"
 			},
 			"devDependencies": {
@@ -348,9 +348,10 @@
 			"integrity": "sha512-ENhwkOW6rnYW8IuXJwvECIAzj7nMxq+ctB8uCJ+mKnoKK8tGiv3YXtN6nuaOov2YmXdRdwafSz9rhgRNXswX/A=="
 		},
 		"node_modules/@egjs/axes": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-3.2.2.tgz",
-			"integrity": "sha512-1GKMQIHv/GYHPM6ccusyybmLOTA0nUMnRajiNjahVFdOcwglS9pUiYpo23MreVuLSUlQvjPWWHQP/LzGPNTTKA==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-3.4.0.tgz",
+			"integrity": "sha512-9XEbYOTPjROLJ9RYDms4JJjaJyrBZN1AWxdpKQqA6PN3lhDQtw6jdgY/e6tfY46L3nWPW5PLdo5woE7cY2sL9Q==",
+			"license": "MIT",
 			"dependencies": {
 				"@egjs/agent": "^2.2.1",
 				"@egjs/component": "^3.0.1"
@@ -6772,9 +6773,9 @@
 			"integrity": "sha512-ENhwkOW6rnYW8IuXJwvECIAzj7nMxq+ctB8uCJ+mKnoKK8tGiv3YXtN6nuaOov2YmXdRdwafSz9rhgRNXswX/A=="
 		},
 		"@egjs/axes": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-3.2.2.tgz",
-			"integrity": "sha512-1GKMQIHv/GYHPM6ccusyybmLOTA0nUMnRajiNjahVFdOcwglS9pUiYpo23MreVuLSUlQvjPWWHQP/LzGPNTTKA==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-3.4.0.tgz",
+			"integrity": "sha512-9XEbYOTPjROLJ9RYDms4JJjaJyrBZN1AWxdpKQqA6PN3lhDQtw6jdgY/e6tfY46L3nWPW5PLdo5woE7cY2sL9Q==",
 			"requires": {
 				"@egjs/agent": "^2.2.1",
 				"@egjs/component": "^3.0.1"

--- a/packages/conveyer/package.json
+++ b/packages/conveyer/package.json
@@ -31,7 +31,7 @@
 		"drag"
 	],
 	"dependencies": {
-		"@egjs/axes": "^3.2.2",
+		"@egjs/axes": "^3.4.0",
 		"@egjs/component": "^3.0.1"
 	},
 	"devDependencies": {

--- a/packages/conveyer/src/Conveyer.ts
+++ b/packages/conveyer/src/Conveyer.ts
@@ -439,7 +439,7 @@ class Conveyer extends Component<ConveyerEvents> {
     }
     if (options.useSideWheel) {
       axes.connect(options.horizontal ? ["scroll", ""] : ["", "scroll"], new WheelInput(scrollAreaElement, {
-        scale: -30,
+        scale: 30,
       }));
     }
     scrollAreaElement.addEventListener("scroll", this._onScroll);

--- a/packages/conveyer/src/types.ts
+++ b/packages/conveyer/src/types.ts
@@ -10,6 +10,7 @@ import Conveyer from "./Conveyer";
  * @property - scroll direction. (true: Horizontal Scroll, false: Vertical Scroll)  (default: true) <ko>스크롤 방향. (true: 가로 스크롤, false: 세로 스크롤) (default: true)</ko>
  * @property - selector to find items inside. (default: "") <ko>내부의 아이템들을 찾기 위한 selector. (default: "")</ko>
  * @property - Whether to use drag (default: true) <ko> 드래그를 사용할지 여부. (default: true)</ko>
+ * @property - Whether to use the mouse wheel in a direction aside from the scroll direction (default: false) <ko>스크롤 방향과 다른 방향의 마우스 휠 입력을 사용할지 여부. (default: false)</ko>
  * @property - The maximum amount of time the scroll event does not fire for the finishScroll event to be triggered. (default: 100) <ko> finishScroll 이벤트가 발생되기 위한 scroll 이벤트가 발생하지 않는 최대 시간. (default: 100)</ko>
  * @property - Whether to prevent being selected. (default: true) <ko>셀렉트가 되는 것을 막을지 여부. (default: true) </ko>
  * @property - Whether to prevent click event when dragging. (default: false) <ko>드래그하면 클릭이벤트를 막을지 여부. (default: true)</ko>
@@ -20,6 +21,7 @@ export interface ConveyerOptions {
   horizontal?: boolean;
   itemSelector?: string;
   useDrag?: boolean;
+  useSideWheel?: boolean;
   scrollDebounce?: number;
   preventDefault?: boolean;
   preventClickOnDrag?: boolean;

--- a/packages/conveyer/test/manual/index.html
+++ b/packages/conveyer/test/manual/index.html
@@ -75,6 +75,7 @@
 <script>
   const conveyer = new Conveyer(".items", {
     preventClickOnDrag: true,
+    useSideWheel: true,
   });
 
   conveyer.on("reachStart", () => {

--- a/packages/conveyer/test/manual/nested.html
+++ b/packages/conveyer/test/manual/nested.html
@@ -1,0 +1,74 @@
+<style>
+  body {
+    background: #F0F3FB;
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  .items {
+    position: relative;
+    overflow: scroll hidden;
+    width: 100%;
+    white-space: nowrap;
+    overscroll-behavior: none;
+    user-select: none;
+  }
+  .container {
+    display: block;
+    position: relative;
+    width: 100%;
+  }
+
+  .item {
+    display: inline-block;
+    overflow: hidden;
+    margin: 18px 12px 30px 0;
+    width: 271px;
+    height: 244px;
+    line-height: 244px;
+    text-align: center;
+    font-weight: bold;
+    font-size: 40px;
+    border-radius: 3px;
+    background-color: #fff;
+    -webkit-box-shadow: 0 2px 2px 0 rgb(0 0 0 / 4%), 0 0 2px 0 rgb(0 0 0 / 15%);
+    box-shadow: 0 2px 2px 0 rgb(0 0 0 / 4%), 0 0 2px 0 rgb(0 0 0 / 15%);
+  }
+</style>
+
+<body>
+  <div class="items">
+    <div class="item">1</div>
+    <div class="item">2</div>
+    <div class="nested item">
+      <div class="item">3.1</div>
+      <div class="item">3.2</div>
+      <div class="item">3.3</div>
+      <div class="item">3.4</div>
+      <div class="item">3.5</div>
+    </div>
+    <div class="item">4</div>
+    <div class="item">5</div>
+    <div class="item">6</div>
+    <div class="item">7</div>
+    <div class="item">8</div>
+    <div class="item">9</div>
+    <div class="item">10</div>
+    <div class="item">11</div>
+    <div class="item">12</div>
+  </div>
+</body>
+<script src="../../dist/conveyer.js"></script>
+<script>
+  const conveyer = new Conveyer(".items", {
+    preventClickOnDrag: true,
+    useSideWheel: true,
+  });
+  conveyer.init();
+  const nested = new Conveyer(".nested", {
+    preventClickOnDrag: true,
+    nested: true,
+    useSideWheel: true,
+  });
+  nested.init();
+</script>

--- a/packages/conveyer/test/manual/vertical.html
+++ b/packages/conveyer/test/manual/vertical.html
@@ -77,6 +77,7 @@
 <script>
   const conveyer = new Conveyer(".items", {
     preventClickOnDrag: true,
+    useSideWheel: true,
     horizontal: false,
   });
 

--- a/packages/conveyer/test/unit/utils/consts.ts
+++ b/packages/conveyer/test/unit/utils/consts.ts
@@ -1,4 +1,4 @@
-export const CONVEYER_STYLE = `<style>
+export const HORIZONTAL_CONVEYER_STYLE = `<style>
   html, body {
     margin: 0;
     padding: 0;
@@ -19,7 +19,28 @@ export const CONVEYER_STYLE = `<style>
   }
 </style>`;
 
-export const CONVEYER_HTML = `${CONVEYER_STYLE}
+export const VERTICAL_CONVEYER_STYLE = `<style>
+  .items {
+    position: relative;
+    overflow: scroll;
+    width: 100%;
+    white-space: nowrap;
+    overscroll-behavior: none;
+    user-select: none;
+    height: 400px;
+    border: 1px solid black;
+  }
+  .item {
+    overflow: hidden;
+    margin: 18px 12px 30px 0;
+    width: 271px;
+    height: 244px;
+    line-height: 244px;
+    border-radius: 3px;
+  }
+</style>`;
+
+export const CONVEYER_HTML = `
 <div class="items">
   <div class="item">1</div>
   <div class="item">2</div>
@@ -35,7 +56,7 @@ export const CONVEYER_HTML = `${CONVEYER_STYLE}
   <div class="item">12</div>
 </div>`;
 
-export const NESTED_CONVEYER_HTML = `${CONVEYER_STYLE}
+export const NESTED_CONVEYER_HTML = `
 <div id="parent" class="items">
   <div class="item">1</div>
   <div class="item">2</div>
@@ -57,3 +78,9 @@ export const NESTED_CONVEYER_HTML = `${CONVEYER_STYLE}
   <div class="item">7</div>
   <div class="item">8</div>
 </div>`;
+
+export const HORIZONTAL_CONVEYER = `${HORIZONTAL_CONVEYER_STYLE}${CONVEYER_HTML}`;
+
+export const VERTICAL_CONVEYER = `${VERTICAL_CONVEYER_STYLE}${CONVEYER_HTML}`;
+
+export const NESTED_CONVEYER = `${HORIZONTAL_CONVEYER_STYLE}${NESTED_CONVEYER_HTML}`;

--- a/packages/conveyer/test/unit/utils/utils.ts
+++ b/packages/conveyer/test/unit/utils/utils.ts
@@ -99,3 +99,22 @@ export async function dispatchMouseMove(target: HTMLElement, moustInit: any, tim
     target.dispatchEvent(mousemove);
   }, time);
 }
+
+export async function dispatchWheel(
+  target: HTMLElement,
+  direction: string,
+  value: number,
+  options: { duration: number; interval: number }
+) {
+  const count = Math.floor(options.duration / options.interval);
+  for (let i = 1; i <= count; ++i) {
+    const wheelEvent = new WheelEvent(
+      "wheel",
+      direction === "horizontal"
+        ? { deltaX: value / count }
+        : { deltaY: value / count }
+    );
+    target.dispatchEvent(wheelEvent);
+    await waitFor(options.interval);
+  }
+}

--- a/packages/conveyer/tsconfig.declaration.json
+++ b/packages/conveyer/tsconfig.declaration.json
@@ -6,7 +6,6 @@
     "emitDeclarationOnly": true,
     "declarationDir": "declaration",
     "strictNullChecks": false,
-    "para"
   },
   "include": [
     "./src/**/*.ts",


### PR DESCRIPTION
## Details
Added `useSideWheel` option to move the Conveyer using the mouse wheel in a direction aside from the scroll direction.
If this option is enabled, horizontal Conveyer will be able to move by using vertical mouse wheel.
Also vertical Conveyer can be moved using the horizontal mouse wheel.

## Behavior for Wheel event with mixed deltaX and deltaY
In some cases, wheel event can have deltaX and deltaY, such as moving the trackpad diagonally.
In this case, only the delta in the same direction as the Conveyer's direction will be applied to the move, even if useSideWheel is active.