### PR TITLE
fix: check autoInit exact to be false to not init

### DIFF
--- a/packages/conveyer/src/reactive.ts
+++ b/packages/conveyer/src/reactive.ts
@@ -27,7 +27,7 @@ export const REACTIVE_CONVEYER: ReactiveAdapter<
     return new Conveyer(data.container, { ...data.props, autoInit: false });
   },
   init(instance, data) {
-    if (data.props.autoInit) {
+    if (data.props.autoInit !== false) {
       instance.init();
     }
   },


### PR DESCRIPTION
## Details
As the logic to `init()` when `if (data.props.autoInit) {` is passed, `init()` does not occur if `data.props.autoInit` is undefined or null.
This solves the above problem by not using `init()` only when `data.props.autoInit` is exact to be false.
