### PR TITLE
Fixed: incorrect main/module/exports.

### DIFF
--- a/packages/svelte-conveyer/package.json
+++ b/packages/svelte-conveyer/package.json
@@ -4,8 +4,8 @@
   "description": "Svelte Conveyer adds Drag gestures to your Native Scroll.",
   "sideEffects": false,
   "types": "declaration/index.d.ts",
-  "module": "dist/imready.esm.js",
-  "main": "dist/imready.cjs.js",
+  "module": "dist/conveyer.esm.js",
+  "main": "dist/conveyer.cjs.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/naver/egjs-conveyer"


### PR DESCRIPTION
Before change this in has an error: [vite] Internal server error: Failed to resolve entry for package "@egjs/svelte-conveyer". The package may have incorrect main/module/exports specified in its package.json.

## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->

## Details
<!-- Detailed description of the change/feature -->
