### PR TITLE
fix: set isHold to false when release occur

### DIFF
--- a/packages/conveyer/src/Conveyer.ts
+++ b/packages/conveyer/src/Conveyer.ts
@@ -426,6 +426,7 @@ class Conveyer extends Component<ConveyerEvents> {
           e.setTo({ ...e.depaPos }, 0);
           this._enableClick();
         }
+        isHold = false;
         isDrag = false;
       },
     });


### PR DESCRIPTION
## Details
`isHold` becomes `true` when "hold" event of axes is fired, and there is no logic to return it to false.
This can cause unexpected behavior in the code such as `this._isAnimation = !!isHold`.

This returns `isHold` to `false` when the release event of axes is fired.