### PR TITLE
fix: scrollIntoView ending earlier than the duration given as an option

### DIFF
--- a/packages/conveyer/src/Conveyer.ts
+++ b/packages/conveyer/src/Conveyer.ts
@@ -485,8 +485,10 @@ class Conveyer extends Component<ConveyerEvents> {
   }
   private _getNextScrollPos(item: ConveyerItem, options: ScrollIntoViewOptions) {
     const size = this._size;
+    const scrollSize = this._scrollSize;
     const align = options.align || "start";
     const padding = options.offset || 0;
+    const fixedDuration = options.fixedDuration || false;
     const itemPos = item!.pos;
     const itemSize = item!.size;
     let scrollPos = 0;
@@ -497,6 +499,9 @@ class Conveyer extends Component<ConveyerEvents> {
       scrollPos = itemPos + itemSize - size + padding;
     } else if (align === "center") {
       scrollPos = itemPos + itemSize / 2 - size / 2 + padding;
+    }
+    if (fixedDuration) {
+      scrollPos = Math.max(0, Math.min(scrollPos, scrollSize - size));
     }
     return scrollPos;
   }

--- a/packages/conveyer/src/Conveyer.ts
+++ b/packages/conveyer/src/Conveyer.ts
@@ -488,7 +488,6 @@ class Conveyer extends Component<ConveyerEvents> {
     const scrollSize = this._scrollSize;
     const align = options.align || "start";
     const padding = options.offset || 0;
-    const fixedDuration = options.fixedDuration || false;
     const itemPos = item!.pos;
     const itemSize = item!.size;
     let scrollPos = 0;
@@ -500,9 +499,7 @@ class Conveyer extends Component<ConveyerEvents> {
     } else if (align === "center") {
       scrollPos = itemPos + itemSize / 2 - size / 2 + padding;
     }
-    if (fixedDuration) {
-      scrollPos = Math.max(0, Math.min(scrollPos, scrollSize - size));
-    }
+    scrollPos = Math.max(0, Math.min(scrollPos, scrollSize - size));
     return scrollPos;
   }
   private _isMixedWheel(nativeEvent: any) {

--- a/packages/conveyer/src/types.ts
+++ b/packages/conveyer/src/types.ts
@@ -71,14 +71,12 @@ export interface FindItemOptions {
  * @property - Whether to find the next item except sorting it in place. (default: false) <ko>아이템을 제자리에 정렬하는 것을 제외하고 다음 아이템을 찾을지 여부. (default: false)</ko>
  * @property - The value to scroll further from the sort position. (default: 0) <ko>정렬하는 위치에서 얼만큼 더 스크롤할 값. (default: 0)</ko>
  * @property - How long to scroll animation time. (default: 0) <ko>얼마동한 스크롤할 할지 애니메이션 시간. (default: 0)</ko>
- * @property - Whether to always use the same duration even if the scroll target point is outside the min/max scroll area. By default, the duration can be different depending on the remaining distance. (default: false) <ko>스크롤 목표 지점이 최소/최대 스크롤 영역 바깥에 있는 경우에도 항상 동일한 duration을 사용할지 여부. 기본적으로는 남은 거리에 따라 duration이 달라질 수 있다. (default: false)</ko>
  */
 export interface ScrollIntoViewOptions extends FindItemOptions {
   align?: "start" | "end" | "center";
   excludeStand?: boolean;
   offset?: number;
   duration?: number;
-  fixedDuration?: boolean;
 }
 
 /**

--- a/packages/conveyer/src/types.ts
+++ b/packages/conveyer/src/types.ts
@@ -71,12 +71,14 @@ export interface FindItemOptions {
  * @property - Whether to find the next item except sorting it in place. (default: false) <ko>아이템을 제자리에 정렬하는 것을 제외하고 다음 아이템을 찾을지 여부. (default: false)</ko>
  * @property - The value to scroll further from the sort position. (default: 0) <ko>정렬하는 위치에서 얼만큼 더 스크롤할 값. (default: 0)</ko>
  * @property - How long to scroll animation time. (default: 0) <ko>얼마동한 스크롤할 할지 애니메이션 시간. (default: 0)</ko>
+ * @property - Whether to always use the same duration even if the scroll target point is outside the min/max scroll area. By default, the duration can be different depending on the remaining distance. (default: false) <ko>스크롤 목표 지점이 최소/최대 스크롤 영역 바깥에 있는 경우에도 항상 동일한 duration을 사용할지 여부. 기본적으로는 남은 거리에 따라 duration이 달라질 수 있다. (default: false)</ko>
  */
 export interface ScrollIntoViewOptions extends FindItemOptions {
   align?: "start" | "end" | "center";
   excludeStand?: boolean;
   offset?: number;
   duration?: number;
+  fixedDuration?: boolean;
 }
 
 /**

--- a/packages/conveyer/test/unit/Conveyer.spec.ts
+++ b/packages/conveyer/test/unit/Conveyer.spec.ts
@@ -554,6 +554,49 @@ describe("test Conveyer", () => {
         expect(items.scrollLeft).to.be.equals(400);
         expect(conveyer.scrollPos).to.be.equals(400);
       });
+      it("should check whether the animation should end early when the target position is outside the scroll area", async () => {
+        // Given
+        conveyer = new Conveyer(".items");
+        // 2 3 4
+        conveyer.scrollTo(200);
+        await waitFor(100);
+
+        // When
+        // to
+        // 1 2 3
+        conveyer.scrollIntoView("start", {
+          align: "end",
+          duration: 1000,
+        });
+        await waitFor(300);
+
+        // Then
+        const items = document.querySelector<HTMLElement>(".items")!;
+        expect(items.scrollLeft).to.be.equals(0);
+        expect(conveyer.scrollPos).to.be.equals(0);
+      });
+      it("should check whether the scroll animate for fixed duration when the target position is outside the scroll area and fixedDuration is true", async () => {
+        // Given
+        conveyer = new Conveyer(".items");
+        // 2 3 4
+        conveyer.scrollTo(200);
+        await waitFor(100);
+
+        // When
+        // to
+        // 1 2 3
+        conveyer.scrollIntoView("start", {
+          align: "end",
+          duration: 1000,
+          fixedDuration: true,
+        });
+        await waitFor(300);
+
+        // Then
+        const items = document.querySelector<HTMLElement>(".items")!;
+        expect(items.scrollLeft).to.be.not.equals(0);
+        expect(conveyer.scrollPos).to.be.not.equals(0);
+      });
     });
   });
   describe("Events", () => {

--- a/packages/conveyer/test/unit/Conveyer.spec.ts
+++ b/packages/conveyer/test/unit/Conveyer.spec.ts
@@ -554,7 +554,7 @@ describe("test Conveyer", () => {
         expect(items.scrollLeft).to.be.equals(400);
         expect(conveyer.scrollPos).to.be.equals(400);
       });
-      it("should check whether the animation should end early when the target position is outside the scroll area", async () => {
+      it("should check whether the scroll animate for given duration even if the target position is outside the scroll area", async () => {
         // Given
         conveyer = new Conveyer(".items");
         // 2 3 4
@@ -567,28 +567,6 @@ describe("test Conveyer", () => {
         conveyer.scrollIntoView("start", {
           align: "end",
           duration: 1000,
-        });
-        await waitFor(300);
-
-        // Then
-        const items = document.querySelector<HTMLElement>(".items")!;
-        expect(items.scrollLeft).to.be.equals(0);
-        expect(conveyer.scrollPos).to.be.equals(0);
-      });
-      it("should check whether the scroll animate for fixed duration when the target position is outside the scroll area and fixedDuration is true", async () => {
-        // Given
-        conveyer = new Conveyer(".items");
-        // 2 3 4
-        conveyer.scrollTo(200);
-        await waitFor(100);
-
-        // When
-        // to
-        // 1 2 3
-        conveyer.scrollIntoView("start", {
-          align: "end",
-          duration: 1000,
-          fixedDuration: true,
         });
         await waitFor(300);
 


### PR DESCRIPTION
## Details

https://codepen.io/malangfox/pen/MWPLWvV
In the above demo, when the `scrollIntoView` is triggered by pressing the button, the scroll moves for 5000ms, but when item 11 is placed at the far right end and the button is pressed, the time it takes to move to the end of the scroll area is not 5000ms.

Fixing this as a bug could lead to a new issue of `scrollIntoView` being slow at the end of the scroll area after updating the version of Conveyer, so I would like to support the existing behavior but add an option to check the minimum/maximum scrollable distance when calculating the distance for `scrollBy` in `scrollIntoView` so that it always has the same scroll animation time.

I'm currently using the `fixedDuration` name as a temporary name, but I'm trying to think of another appropriate name.
