### PR TITLE
feat: add boundaryMargin option

### DIFF
--- a/packages/conveyer/src/Conveyer.ts
+++ b/packages/conveyer/src/Conveyer.ts
@@ -110,6 +110,7 @@ class Conveyer extends Component<ConveyerEvents> {
       useDrag: true,
       useSideWheel: false,
       autoInit: true,
+      boundaryMargin: 0,
       scrollDebounce: 100,
       ...options,
     };
@@ -524,9 +525,10 @@ class Conveyer extends Component<ConveyerEvents> {
     const size = this._size;
     const scrollSize = this._scrollSize;
     const pos = this._pos;
+    const boundaryMargin = this._options.boundaryMargin ?? 0;
 
     // enter start
-    if (pos <= 0 && this.isReachStart !== true) {
+    if (pos <= boundaryMargin && this.isReachStart !== true) {
       this._isReachStart = true;
       /**
        * This event is fired when scroll reach start.
@@ -534,7 +536,7 @@ class Conveyer extends Component<ConveyerEvents> {
        * @event Conveyer#reachStart
        */
       this.trigger("reachStart");
-    } else if (pos > 0 && this.isReachStart !== false) {
+    } else if (pos > boundaryMargin && this.isReachStart !== false) {
       this._isReachStart = false;
       /**
        * This event is fired when scroll leave start.
@@ -544,7 +546,7 @@ class Conveyer extends Component<ConveyerEvents> {
       this.trigger("leaveStart");
     }
     // enter end
-    if (scrollSize - size - pos < 1 && this.isReachEnd !== true) {
+    if (scrollSize - size - pos < 1 + boundaryMargin && this.isReachEnd !== true) {
       this._isReachEnd = true;
       /**
        * This event is fired when scroll reach end.
@@ -552,7 +554,7 @@ class Conveyer extends Component<ConveyerEvents> {
        * @event Conveyer#reachEnd
        */
       this.trigger("reachEnd");
-    } else if (!(scrollSize - size - pos < 1) && this.isReachEnd !== false) {
+    } else if (!(scrollSize - size - pos < 1 + boundaryMargin) && this.isReachEnd !== false) {
       this._isReachEnd = false;
       /**
        * This event is fired when scroll leave end.

--- a/packages/conveyer/src/types.ts
+++ b/packages/conveyer/src/types.ts
@@ -11,6 +11,8 @@ import Conveyer from "./Conveyer";
  * @property - selector to find items inside. (default: "") <ko>내부의 아이템들을 찾기 위한 selector. (default: "")</ko>
  * @property - Whether to use drag (default: true) <ko> 드래그를 사용할지 여부. (default: true)</ko>
  * @property - Whether to use the mouse wheel in a direction aside from the scroll direction (default: false) <ko>스크롤 방향과 다른 방향의 마우스 휠 입력을 사용할지 여부. (default: false)</ko>
+ * @property - The minimum margin space for {@link Conveyer#event-reachStart reachStart}, {@link Conveyer#event-leaveStart leaveStart}, {@link Conveyer#event-reachEnd reachEnd}, and {@link Conveyer#event-leaveEnd leaveEnd} events to occur at the beginning and end of the scroll area. (default: 0)
+ * <ko> 스크롤 영역의 시작과 끝에서 {@link Conveyer#event-reachStart reachStart}, {@link Conveyer#event-leaveStart leaveStart}, {@link Conveyer#event-reachEnd reachEnd}, {@link Conveyer#event-leaveEnd leaveEnd} 이벤트들이 발생하기 위한 최소 여백. (default: 0)</ko>
  * @property - The maximum amount of time the scroll event does not fire for the finishScroll event to be triggered. (default: 100) <ko> finishScroll 이벤트가 발생되기 위한 scroll 이벤트가 발생하지 않는 최대 시간. (default: 100)</ko>
  * @property - Whether to prevent being selected. (default: true) <ko>셀렉트가 되는 것을 막을지 여부. (default: true) </ko>
  * @property - Whether to prevent click event when dragging. (default: false) <ko>드래그하면 클릭이벤트를 막을지 여부. (default: true)</ko>
@@ -22,6 +24,7 @@ export interface ConveyerOptions {
   itemSelector?: string;
   useDrag?: boolean;
   useSideWheel?: boolean;
+  boundaryMargin?: number;
   scrollDebounce?: number;
   preventDefault?: boolean;
   preventClickOnDrag?: boolean;

--- a/packages/conveyer/src/types.ts
+++ b/packages/conveyer/src/types.ts
@@ -11,7 +11,7 @@ import Conveyer from "./Conveyer";
  * @property - selector to find items inside. (default: "") <ko>내부의 아이템들을 찾기 위한 selector. (default: "")</ko>
  * @property - Whether to use drag (default: true) <ko> 드래그를 사용할지 여부. (default: true)</ko>
  * @property - Whether to use the mouse wheel in a direction aside from the scroll direction (default: false) <ko>스크롤 방향과 다른 방향의 마우스 휠 입력을 사용할지 여부. (default: false)</ko>
- * @property - The minimum margin space for {@link Conveyer#event-reachStart reachStart}, {@link Conveyer#event-leaveStart leaveStart}, {@link Conveyer#event-reachEnd reachEnd}, and {@link Conveyer#event-leaveEnd leaveEnd} events to occur at the beginning and end of the scroll area. (default: 0)
+ * @property - The minimum margin space for {@link Conveyer#event-reachStart reachStart}, {@link Conveyer#event-leaveStart leaveStart}, {@link Conveyer#event-reachEnd reachEnd}, and {@link Conveyer#event-leaveEnd leaveEnd} events to be triggered at the beginning and end of the scroll area. (default: 0)
  * <ko> 스크롤 영역의 시작과 끝에서 {@link Conveyer#event-reachStart reachStart}, {@link Conveyer#event-leaveStart leaveStart}, {@link Conveyer#event-reachEnd reachEnd}, {@link Conveyer#event-leaveEnd leaveEnd} 이벤트들이 발생하기 위한 최소 여백. (default: 0)</ko>
  * @property - The maximum amount of time the scroll event does not fire for the finishScroll event to be triggered. (default: 100) <ko> finishScroll 이벤트가 발생되기 위한 scroll 이벤트가 발생하지 않는 최대 시간. (default: 100)</ko>
  * @property - Whether to prevent being selected. (default: true) <ko>셀렉트가 되는 것을 막을지 여부. (default: true) </ko>

--- a/packages/conveyer/test/unit/Conveyer.spec.ts
+++ b/packages/conveyer/test/unit/Conveyer.spec.ts
@@ -699,6 +699,45 @@ describe("test Conveyer", () => {
       });
     });
 
+    describe("boundaryMargin", () => {
+      const NEARBY_DISTANCE = 20;
+
+      [10, 30].forEach((boundaryMargin) => {
+        const isMarginEnough = boundaryMargin >= NEARBY_DISTANCE;
+
+        it(`should check if the boundaryMargin affects the scroll positions at which events are triggered (boundaryMargin is ${isMarginEnough ? "more" : "less"} than blank space)`, async () => {
+          // Given
+          conveyer = new Conveyer(".items", {
+            boundaryMargin,
+          });
+
+          // When
+          const leaveStartSpy = sinon.spy();
+          const reachEndSpy = sinon.spy();
+          const leaveEndSpy = sinon.spy();
+          const reachStartSpy = sinon.spy();
+          const items = document.querySelector<HTMLElement>(".items")!;
+          conveyer.init();
+          conveyer.scrollTo(NEARBY_DISTANCE);
+          await waitFor(100);
+          conveyer.on("reachStart", reachStartSpy);
+          conveyer.on("leaveStart", leaveStartSpy);
+          conveyer.on("reachEnd", reachEndSpy);
+          conveyer.on("leaveEnd", leaveEndSpy);
+          conveyer.scrollTo(items.scrollWidth - items.clientWidth - NEARBY_DISTANCE);
+          await waitFor(100);
+          conveyer.scrollTo(NEARBY_DISTANCE);
+          await waitFor(100);
+
+          // Then
+          expect(leaveStartSpy.callCount).to.be.equals(isMarginEnough ? 1 : 0);
+          expect(reachEndSpy.callCount).to.be.equals(isMarginEnough ? 1 : 0);
+          expect(leaveEndSpy.callCount).to.be.equals(isMarginEnough ? 1 : 0);
+          expect(reachStartSpy.callCount).to.be.equals(isMarginEnough ? 1 : 0);
+        });
+      });
+    });
+
     describe("nested", () => {
       let childConveyer!: Conveyer;
 


### PR DESCRIPTION
This adds the option `boundaryMargin`, which sets the margin space for the `reachStart`, `leaveStart`, `reachEnd`, and `leaveEnd` events to be triggered at the start and end of the scroll area.