### PR TITLE
fix: fix incorrect isTrusted value in finishScroll event

### DIFF
--- a/packages/conveyer/src/Conveyer.ts
+++ b/packages/conveyer/src/Conveyer.ts
@@ -44,9 +44,9 @@ class Conveyer extends Component<ConveyerEvents> {
   protected _options: ConveyerOptions;
 
   private _scrollTimer = 0;
-  private _isNativeScroll = false;
+  private _isWheelScroll = false;
   private _isDragScroll = false;
-  private _isAnimation = false;
+  private _isAnimationScroll = false;
   private _scrollArea: string | HTMLElement | Ref<HTMLElement>;
 
   /**
@@ -409,9 +409,9 @@ class Conveyer extends Component<ConveyerEvents> {
         if (options.useSideWheel && this._isMixedWheel(nativeEvent)) {
           return;
         }
-        this._isNativeScroll = !!nativeEvent && nativeEvent.type === "wheel";
-        this._isDragScroll = !!nativeEvent && !this._isNativeScroll;
-        this._isAnimation = !this._isNativeScroll && !isHold;
+        this._isWheelScroll = !!nativeEvent && nativeEvent.type === "wheel";
+        this._isDragScroll = !!nativeEvent && !this._isWheelScroll;
+        this._isAnimationScroll = !this._isWheelScroll && !isHold;
         isDrag = true;
         const scroll = e.delta.scroll;
 
@@ -583,6 +583,9 @@ class Conveyer extends Component<ConveyerEvents> {
     }
     window.clearTimeout(this._scrollTimer);
     this._scrollTimer = window.setTimeout(() => {
+      const isWheelScroll = this._isWheelScroll;
+      const isDragScroll = this._isDragScroll;
+      const isAnimationScroll = this._isAnimationScroll;
       this._scrollTimer = 0;
       /**
        * This event is fired when finish scroll.
@@ -591,13 +594,15 @@ class Conveyer extends Component<ConveyerEvents> {
        * @param {OnFinishScroll} e - The object of data to be sent to an event <ko>이벤트에 전달되는 데이터 객체</ko>
        */
       this.trigger("finishScroll", {
-        isDragScroll: this._isDragScroll,
-        isTrusted: this._isNativeScroll || this._isDragScroll || !this._isAnimation,
+        isWheelScroll,
+        isDragScroll,
+        isAnimationScroll,
+        isTrusted: isWheelScroll || isDragScroll || !isAnimationScroll,
       });
 
-      this._isNativeScroll = false;
+      this._isWheelScroll = false;
       this._isDragScroll = false;
-      this._isAnimation = false;
+      this._isAnimationScroll = false;
     }, this._options.scrollDebounce);
   }
 }

--- a/packages/conveyer/src/Conveyer.ts
+++ b/packages/conveyer/src/Conveyer.ts
@@ -44,6 +44,7 @@ class Conveyer extends Component<ConveyerEvents> {
   protected _options: ConveyerOptions;
 
   private _scrollTimer = 0;
+  private _isNativeScroll = false;
   private _isDragScroll = false;
   private _isAnimation = false;
   private _scrollArea: string | HTMLElement | Ref<HTMLElement>;
@@ -405,14 +406,12 @@ class Conveyer extends Component<ConveyerEvents> {
       },
       "change": e => {
         const nativeEvent = this._getNativeEvent(e);
-        if (nativeEvent && !isHold) {
-          return;
-        }
         if (options.useSideWheel && this._isMixedWheel(nativeEvent)) {
           return;
         }
-        this._isDragScroll = !!nativeEvent && nativeEvent.type !== "wheel";
-        this._isAnimation = !!isHold;
+        this._isNativeScroll = !!nativeEvent && nativeEvent.type === "wheel";
+        this._isDragScroll = !!nativeEvent && !this._isNativeScroll;
+        this._isAnimation = !this._isNativeScroll && !isHold;
         isDrag = true;
         const scroll = e.delta.scroll;
 
@@ -593,9 +592,10 @@ class Conveyer extends Component<ConveyerEvents> {
        */
       this.trigger("finishScroll", {
         isDragScroll: this._isDragScroll,
-        isTrusted: this._isDragScroll || !this._isAnimation,
+        isTrusted: this._isNativeScroll || this._isDragScroll || !this._isAnimation,
       });
 
+      this._isNativeScroll = false;
       this._isDragScroll = false;
       this._isAnimation = false;
     }, this._options.scrollDebounce);

--- a/packages/conveyer/src/types.ts
+++ b/packages/conveyer/src/types.ts
@@ -33,7 +33,9 @@ export interface ConveyerOptions {
  * @typedef
  */
 export interface OnFinishScroll {
+  isWheelScroll: boolean;
   isDragScroll: boolean;
+  isAnimationScroll: boolean;
   isTrusted: boolean;
 }
 

--- a/packages/conveyer/test/unit/Conveyer.spec.ts
+++ b/packages/conveyer/test/unit/Conveyer.spec.ts
@@ -670,6 +670,41 @@ describe("test Conveyer", () => {
       // Then
       expect(spy.callCount).to.be.equals(1);
     });
+    it("should check if isTrusted of finishScroll event is true when drag occurs", (done) => {
+      // Given
+      const items = document.querySelector<HTMLElement>(".items")!;
+      const finishScrollHandler = sinon.spy((event) => {
+        // Then
+        expect(event.isTrusted).to.be.true;
+        done();
+      });
+
+      conveyer = new Conveyer(items);
+      conveyer.on("finishScroll", finishScrollHandler);
+
+      // When
+      dispatchDrag(
+        items,
+        { left: 0, top: 0 },
+        { left: -100, top: 0 },
+        { duration: 100, interval: 50 }
+      );
+    });
+    it("should check if isTrusted of finishScroll event is false when conveyer moves by method", (done) => {
+      // Given
+      const items = document.querySelector<HTMLElement>(".items")!;
+      const finishScrollHandler = sinon.spy((event) => {
+        // Then
+        expect(event.isTrusted).to.be.false;
+        done();
+      });
+
+      conveyer = new Conveyer(items);
+      conveyer.on("finishScroll", finishScrollHandler);
+
+      // When
+      conveyer.scrollTo(600);
+    });
   });
   describe("Options", () => {
     describe("useSideWheel", () => {


### PR DESCRIPTION
## Details
This sets the `isTrusted` value in `finishScroll` event more accurately after fixing the bug in #34.

First, I removed the following logic from the `change` event.
`if (nativeEvent && !isHold) { return; }`
Removing this part will not change the behavior, as it was working correctly in the previous situation where `isHold` was being calculated as `true`.


And I fixed an issue where `_isAnimation` was being set incorrectly, affecting the `isTrusted` value of finishScroll event.

`_isAnimation` should be set to `true` when conveyer is not in a holding state and a `change` event is not fired by the user wheel, assuming that `change` event has occurred due to internal methods.