### PR TITLE
fix: fix scroll methods moving to invalid position

### DIFF
--- a/packages/conveyer/src/Conveyer.ts
+++ b/packages/conveyer/src/Conveyer.ts
@@ -46,6 +46,7 @@ class Conveyer extends Component<ConveyerEvents> {
   
   private _resizeObserver: ResizeObserver | null = null;
   private _scrollTimer = 0;
+  private _animationPos = 0;
   private _isWheelScroll = false;
   private _isDragScroll = false;
   private _isAnimationScroll = false;
@@ -289,6 +290,7 @@ class Conveyer extends Component<ConveyerEvents> {
    * @param - Duration to scroll by that position. <ko>해당 위치만큼 스크롤하는 시간</ko>
    */
   public scrollBy(pos: number, duration = 0) {
+    this._animationPos = this._pos + pos;
     this._axes!.setBy({ scroll: -pos }, duration);
   }
   /**
@@ -298,6 +300,7 @@ class Conveyer extends Component<ConveyerEvents> {
    * @param - Duration to scroll to that position. <ko>해당 위치로 스크롤하는 시간</ko>
    */
   public scrollTo(pos: number, duration = 0) {
+    this._animationPos = pos;
     this._axes!.setBy({ scroll: this._pos - pos }, duration);
   }
   /**
@@ -445,6 +448,11 @@ class Conveyer extends Component<ConveyerEvents> {
         }
         if (options.nested) {
           this._checkNestedMove(nativeEvent);
+        }
+      },
+      "animationEnd": e => {
+        if (!e.isTrusted && this._pos !== this._animationPos) {
+          this.scrollTo(this._animationPos);
         }
       },
       "release": e => {

--- a/packages/conveyer/src/Conveyer.ts
+++ b/packages/conveyer/src/Conveyer.ts
@@ -44,9 +44,6 @@ class Conveyer extends Component<ConveyerEvents> {
   protected _scrollSize = 0;
   protected _options: ConveyerOptions;
   protected _animateParam: {
-    startTime: number;
-    duration: number;
-    destPos: number;
     expectedPos: number;
   } | null = null;
 
@@ -295,7 +292,7 @@ class Conveyer extends Component<ConveyerEvents> {
    * @param - Duration to scroll by that position. <ko>해당 위치만큼 스크롤하는 시간</ko>
    */
   public scrollBy(pos: number, duration = 0) {
-    this._createAnimationParam(this._pos, this._pos + pos, duration);
+    this._createAnimationParam();
     this._axes!.setBy({ scroll: -pos }, duration);
   }
   /**
@@ -305,7 +302,7 @@ class Conveyer extends Component<ConveyerEvents> {
    * @param - Duration to scroll to that position. <ko>해당 위치로 스크롤하는 시간</ko>
    */
   public scrollTo(pos: number, duration = 0) {
-    this._createAnimationParam(this._pos, pos, duration);
+    this._createAnimationParam();
     this._axes!.setBy({ scroll: this._pos - pos }, duration);
   }
   /**
@@ -446,34 +443,23 @@ class Conveyer extends Component<ConveyerEvents> {
         this._isAnimationScroll = !this._isWheelScroll && !isHold;
         isDrag = true;
         const scroll = e.delta.scroll;
-        if (options.horizontal) {
-          scrollAreaElement.scrollLeft -= scroll;
-        } else {
-          scrollAreaElement.scrollTop -= scroll;
-        }
         if (!e.isTrusted && animateParam) {
           animateParam.expectedPos -= scroll;
-          const scrollPos = options.horizontal ? scrollAreaElement.scrollLeft : scrollAreaElement.scrollTop;
-          const diffPos = animateParam.expectedPos - scrollPos;
-          if (Math.abs(diffPos) >= 1) {
-            if (options.horizontal) {
-              scrollAreaElement.scrollLeft += diffPos;
-            } else {
-              scrollAreaElement.scrollTop += diffPos;
-            }
+          if (options.horizontal) {
+            scrollAreaElement.scrollLeft = animateParam.expectedPos;
+          } else {
+            scrollAreaElement.scrollTop = animateParam.expectedPos;
           }
         } else {
           this._animateParam = null;
+          if (options.horizontal) {
+            scrollAreaElement.scrollLeft -= scroll;
+          } else {
+            scrollAreaElement.scrollTop -= scroll;
+          }
         }
         if (options.nested) {
           this._checkNestedMove(nativeEvent);
-        }
-      },
-      "animationEnd": e => {
-        const animateParam = this._animateParam;
-        const isCanceled = !(animateParam && new Date().getTime() - animateParam.duration >= animateParam.startTime);
-        if (!e.isTrusted && !isCanceled && this._pos !== animateParam.destPos) {
-          this.scrollTo(animateParam.destPos);
         }
       },
       "release": e => {
@@ -677,12 +663,9 @@ class Conveyer extends Component<ConveyerEvents> {
     }, this._options.scrollDebounce);
   }
 
-  private _createAnimationParam(depaPos: number, destPos: number, duration: number) {
+  private _createAnimationParam() {
     this._animateParam = {
-      destPos,
-      duration,
-      startTime: new Date().getTime(),
-      expectedPos: depaPos,
+      expectedPos: this._pos,
     };
   }
 }

--- a/packages/conveyer/src/Conveyer.ts
+++ b/packages/conveyer/src/Conveyer.ts
@@ -46,9 +46,8 @@ class Conveyer extends Component<ConveyerEvents> {
   protected _animateParam: {
     startTime: number;
     duration: number;
-    depaPos: number;
     destPos: number;
-    latestDiff: number;
+    expectedPos: number;
   } | null = null;
 
   private _resizeObserver: ResizeObserver | null = null;
@@ -453,21 +452,16 @@ class Conveyer extends Component<ConveyerEvents> {
           scrollAreaElement.scrollTop -= scroll;
         }
         if (!e.isTrusted && animateParam?.duration) {
-          const easing = this._axes!.options.easing!;
-          const diffTime = new Date().getTime() - animateParam.startTime;
-          const ratio = diffTime / animateParam.duration;
-          const delta = animateParam.destPos - animateParam.depaPos;
+          animateParam.expectedPos -= scroll;
           const scrollPos = options.horizontal ? scrollAreaElement.scrollLeft : scrollAreaElement.scrollTop;
-          const expectedPos = animateParam.depaPos + easing(ratio) * delta;
-          const diffPos = expectedPos - scrollPos;
-          if (Math.abs(diffPos) >= 1 && Math.abs(animateParam.latestDiff) >= 1) {
+          const diffPos = animateParam.expectedPos - scrollPos;
+          if (Math.abs(diffPos) >= 1) {
             if (options.horizontal) {
               scrollAreaElement.scrollLeft += diffPos;
             } else {
               scrollAreaElement.scrollTop += diffPos;
             }
           }
-          animateParam.latestDiff = diffPos;
         } else {
           this._animateParam = null;
         }
@@ -685,11 +679,10 @@ class Conveyer extends Component<ConveyerEvents> {
 
   private _createAnimationParam(depaPos: number, destPos: number, duration: number) {
     this._animateParam = {
-      depaPos,
       destPos,
       duration,
       startTime: new Date().getTime(),
-      latestDiff: 0,
+      expectedPos: depaPos,
     };
   }
 }

--- a/packages/conveyer/src/Conveyer.ts
+++ b/packages/conveyer/src/Conveyer.ts
@@ -320,13 +320,13 @@ class Conveyer extends Component<ConveyerEvents> {
     const itemSelector = this._options.itemSelector;
     const resizeObserver = this._resizeObserver;
     const prevItemElements = this._items.map(item => item.element!);
-    
+
     const itemElements = [].slice.call(
       itemSelector ? scrollAreaElement.querySelectorAll(itemSelector) : scrollAreaElement.children,
-      );
-      this.setItems(itemElements.map((el) => this._getItem(el)));
-      
-      if (resizeObserver){
+    );
+    this.setItems(itemElements.map((el) => this._getItem(el)));
+
+    if (resizeObserver){
       const changed = diff(prevItemElements, itemElements);
       const removed = changed.removed;
       const added = changed.added;

--- a/packages/conveyer/src/Conveyer.ts
+++ b/packages/conveyer/src/Conveyer.ts
@@ -451,7 +451,7 @@ class Conveyer extends Component<ConveyerEvents> {
         } else {
           scrollAreaElement.scrollTop -= scroll;
         }
-        if (!e.isTrusted && animateParam?.duration) {
+        if (!e.isTrusted && animateParam) {
           animateParam.expectedPos -= scroll;
           const scrollPos = options.horizontal ? scrollAreaElement.scrollLeft : scrollAreaElement.scrollTop;
           const diffPos = animateParam.expectedPos - scrollPos;


### PR DESCRIPTION
## Issue
#52 

## Details
https://codepen.io/malangfox/pen/bGOqJKE
If you zoom in to 125% and press the NEXT button multiple times, it malfunctions at the end.

This is related to the animation that occurs during the `axes.setBy` in scroll methods.

When the animation runs, an integer value is added to the scroll position based on the elapsed time, but this integer value is converted to a decimal value at `scrollLeft`, `scrollTop` when the browser's zoom changes.

You can check [this](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/dom/element.cc;l=943;drc=9f265202bb4eb3245f8ea815c50610e9136c3f1e) link and [this](https://bugs.chromium.org/p/chromium/issues/detail?id=890345) link that the scroll value is converted to a decimal value related to the browser's zoom.

As a result, the problem of mixing decimal values in the math causes the method to reach an incorrect destination.

My approach to this issue was as follows.
- Even if you apply a math.ceil value to `scrollLeft`, the browser will convert it to a decimal value.
- If you give `axes.setBy` a duration of 0, it will immediately move to that coordinates without animation.
- The occurrence of animation by the scroll method can be detected by the `animationEnd` event of axes.
- We can correct the scroll position using `setBy` when the animation is finished. This is only off by a few pixels, so it seems okay.
- Correcting the value at this point will not fire unnecessary events such as `finishScroll` on the conveyer.
- Animation caused by user input can be filtered out through the `isTrusted` value.

